### PR TITLE
Fixes #9 : Output and input box clears on New Session

### DIFF
--- a/src/mainwindow.cc
+++ b/src/mainwindow.cc
@@ -271,6 +271,13 @@ void MainWindow::launchSession() {
   }
 
   this->window()->setWindowTitle("CP Editor: Temporary buffer");
+  ui->in1->clear();
+  ui->in2->clear();
+  ui->in3->clear();
+
+  ui->out1->clear();
+  ui->out2->clear();
+  ui->out3->clear();
 }
 
 // ******************* STATUS::ACTIONS FILE **************************


### PR DESCRIPTION
Wrote the code for clearing the input and output boxes on launching a new session [Issue #9](https://github.com/coder3101/cp-editor2/issues/9)