### PR TITLE
fix(main): open file with unicode in path

### DIFF
--- a/src/main.cc
+++ b/src/main.cc
@@ -22,7 +22,8 @@
 
 int main(int argc, char* argv[]) {
   QApplication a(argc, argv);
-  QString filePath = argc > 1 ? argv[1]: "";
+  QStringList args = a.arguments();
+  QString filePath = args.size() > 1 ? args[1]: "";
   MainWindow w(filePath);
   w.show();
   return a.exec();


### PR DESCRIPTION
In the old version, you can't open a file with Unicode in its path (Ctrl+O works well, but opening by the command-line argument doesn't). This PR fixes it.