### PR TITLE
fix(mainwindow.cc): restore save tests setting

### DIFF
--- a/src/mainwindow.cc
+++ b/src/mainwindow.cc
@@ -242,6 +242,9 @@ void MainWindow::restoreSettings() {
 
   ui->actionBeta_Updates->setChecked(
       setting->isBeta());
+
+  ui->actionSave_Tests->setChecked(
+      setting->isSaveTests());
 }
 
 void MainWindow::runEditorDiagonistics() {


### PR DESCRIPTION
I think it should be my mistake when using git. I remember this setting is restored when I tested it locally. 😢